### PR TITLE
Ignore Dockerfile for docker cache

### DIFF
--- a/src/.github/workflows/ci.yml.jinja
+++ b/src/.github/workflows/ci.yml.jinja
@@ -93,8 +93,7 @@ jobs:
               /tmp/.buildx-cache
             key:
             {%- raw %}
-              buildx|${{ secrets.CACHE_DATE }}|${{ runner.os }}|${{
-              hashFiles('Dockerfile') }}
+              buildx|${{ secrets.CACHE_DATE }}|${{ runner.os }}
             {%- endraw %}
         - name: Set up QEMU
           uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
I think this was wrong as it was. Several reasons:

1. The `Dockerfile` could `COPY ./something /in/the/image`, and `./something` wouldn't be taken into account for caching.
2. A new patch to the `Dockerfile` could easily just add a new command, without necessarily having to invalidate cache for other layers of the build.
3. Docker will rebuild a layer automatically if the instruction and base layer has changed, so putting there the cache always wouldn't harm.

So, considering all this, I think that the cache should just ignore everything related to the source code, and just cache all always and let Docker choose what to use and what to ignore.