### PR TITLE
Add simple test as base

### DIFF
--- a/src/{% if pytest %}tests{% endif %}/conftest.py.jinja
+++ b/src/{% if pytest %}tests{% endif %}/conftest.py.jinja
@@ -1,8 +1,10 @@
 {% if pytest %}
 import logging
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from plumbum import local
 from plumbum.cmd import docker
 
 _logger = logging.getLogger(__name__)
@@ -39,5 +41,34 @@ def image(request):
         )
         assert not retcode, "Image build failed"
     return image
+
+@pytest.fixture(scope="session")
+def container_factory(image):
+    """A context manager that starts the docker container."""
+
+    @contextmanager
+    def _container():
+        container_id = None
+        _logger.info(f"Starting {image} container")
+        try:
+            container_id = docker(
+                "container",
+                "run",
+                "--detach",
+                image,
+            ).strip()
+            with local.env():
+                yield container_id
+        finally:
+            if container_id:
+                _logger.info(f"Removing {container_id}...")
+                docker(
+                    "container",
+                    "rm",
+                    "-f",
+                    container_id,
+                )
+
+    return _container
 
 {% endif %}

--- a/src/{% if pytest %}tests{% endif %}/test_service.py.jinja
+++ b/src/{% if pytest %}tests{% endif %}/test_service.py.jinja
@@ -1,0 +1,13 @@
+{% if pytest %}
+import logging
+
+from plumbum.cmd import docker
+
+logger = logging.getLogger()
+
+
+def test_service(container_factory):
+    with container_factory() as test_container:
+        return
+
+{% endif %}


### PR DESCRIPTION
Add a context manager that launches the container for the test and deletes it at the end.
Add a simple test to serve as base.